### PR TITLE
add tinydns backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 spec/fixtures/*
 Gemfile.lock
 pkg
+vendor/
+.bundle/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All parameters specific to a backend can be supplied using the `options` paramet
   - SQLite3 (`gsqlite3`)
   - LMDB (`lmdb`)
   - Pipe (`pipe`)
+  - TinyDNS ('tinydns')
 
 ### PowerDNS with MySQL (using manifests)
 

--- a/manifests/backend/tinydns.pp
+++ b/manifests/backend/tinydns.pp
@@ -20,7 +20,7 @@ class powerdns::backend::tinydns (
   $tai_adjust = '11',
   $notify_on_startup = 'no',
   $ignore_bogus_records = 'no',
-  $locations = 'no',
+  $locations = 'yes',
 ) {
   $backend_package_name = 'pdns-backend-tinydns'
 

--- a/manifests/backend/tinydns.pp
+++ b/manifests/backend/tinydns.pp
@@ -1,0 +1,46 @@
+# == Class: powerdns::backend::tinydns
+#
+# Copyright 2016 Mark McKinstry <mmckinst@nexcess.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class powerdns::backend::tinydns (
+  $dbfile,
+  $tai_adjust = '11',
+  $notify_on_startup = 'no',
+  $ignore_bogus_records = 'no',
+  $locations = 'no',
+) {
+  $backend_package_name = 'pdns-backend-tinydns'
+
+  package { $backend_package_name:
+    ensure => $::powerdns::install::package_ensure,
+  }
+
+  $options = {
+    'dbfile'               => $dbfile,
+    'tai-adjust'           => $tai_adjust,
+    'notify-on-startup'    => $notify_on_startup,
+    'ignore-bogus-records' => $ignore_bogus_records,
+    'locations'            => $locations,
+  }
+
+  file { "${::powerdns::config::config_path}/pdns.d/tinydns.conf":
+    ensure  => present,
+    content => template("${module_name}/backend.conf.erb"),
+    owner   => $::powerdns::config::config_owner,
+    group   => $::powerdns::config::config_group,
+    mode    => $::powerdns::config::config_mode,
+  }
+}

--- a/spec/classes/backend/tinydns_spec.rb
+++ b/spec/classes/backend/tinydns_spec.rb
@@ -1,0 +1,53 @@
+describe "powerdns::backend::tinydns" do
+  let (:params) do
+    {
+      :dbfile => '/var/tmp/pdns.cdb',
+    }
+  end
+
+  context "on Debian" do
+    let (:pre_condition) { 'include ::powerdns' }
+
+    let (:facts) do
+      {
+        :osfamily => 'Debian'
+      }
+    end
+
+    it { should compile.with_all_deps }
+    it { should create_class(class_name) }
+    it { should contain_package('pdns-backend-tinydns') }
+
+    it do
+      should create_file('/etc/powerdns/pdns.d/tinydns.conf').with({
+        :ensure => 'present',
+        :owner  => 'root',
+        :group  => 'root',
+        :mode   => '0600',
+     })
+    end
+  end
+
+  context "on RedHat" do
+    let (:pre_condition) { 'include ::powerdns' }
+
+    let (:facts) do
+      {
+        :osfamily => 'RedHat'
+      }
+    end
+
+    it { should compile.with_all_deps }
+    it { should create_class(class_name) }
+    it { should contain_package('pdns-backend-tinydns') }
+
+    it do
+      should create_file('/etc/pdns/pdns.d/tinydns.conf').with({
+        :ensure => 'present',
+        :owner  => 'root',
+        :group  => 'root',
+        :mode   => '0600',
+     })
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,5 @@ SUPPORTED_BACKENDS = [
   'pipe',
   'gpgsql',
   'gsqlite3',
+  'tinydns',
 ]


### PR DESCRIPTION
The default settings for the backened are copied from https://doc.powerdns.com/3/authoritative/backend-tinydns/ .
