### PR TITLE
Add option for enabling DNSSEC support for generic SQL backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All parameters specific to a backend can be supplied using the `options` paramet
       password => 'password',
       dbname   => 'powerdns',
       port     => '3306',
+      dnssec   => 'yes'
     }
 
 ### PowerDNS with PostgreSQL (using Hiera)
@@ -69,6 +70,7 @@ All parameters specific to a backend can be supplied using the `options` paramet
     powerdns::backend::gpgsql::password: 'password'
     powerdns::backend::gpgsql::dbname:   'powerdns'
     powerdns::backend::gpgsql::port:     5432
+    powerdns::backend::gpgsql::dnssec:   'no'
 
 ## Todo
 

--- a/manifests/backend/gmysql.pp
+++ b/manifests/backend/gmysql.pp
@@ -21,6 +21,7 @@ class powerdns::backend::gmysql (
   $password,
   $dbname,
   $port = 3306,
+  $dnssec = 'no'
 ) {
   $backend_package_name = 'pdns-backend-mysql'
 
@@ -34,6 +35,7 @@ class powerdns::backend::gmysql (
     'password' => $password,
     'dbname'   => $dbname,
     'port'     => $port,
+    'dnssec'   => $dnssec
   }
 
   file { "${::powerdns::config::config_path}/pdns.d/gmysql.conf":

--- a/manifests/backend/gpgsql.pp
+++ b/manifests/backend/gpgsql.pp
@@ -21,6 +21,7 @@ class powerdns::backend::gpgsql (
   $password,
   $dbname,
   $port = 5432,
+  $dnssec = 'no'
 ) {
   $backend_package_name = $::osfamily ? {
     'RedHat' => 'pdns-backend-postgresql',
@@ -37,6 +38,7 @@ class powerdns::backend::gpgsql (
     'password' => $password,
     'dbname'   => $dbname,
     'port'     => $port,
+    'dnssec'   => $dnssec
   }
 
   file { "${::powerdns::config::config_path}/pdns.d/gpgsql.conf":

--- a/manifests/backend/gsqlite3.pp
+++ b/manifests/backend/gsqlite3.pp
@@ -19,6 +19,7 @@ class powerdns::backend::gsqlite3 (
   $database,
   $synchronous,
   $foreign_keys,
+  $dnssec = 'no'
 ) {
   $backend_package_name = $::osfamily ? {
     'Debian' => 'pdns-backend-sqlite3',
@@ -33,6 +34,7 @@ class powerdns::backend::gsqlite3 (
     'database'            => $database,
     'pragma-synchronous'  => $synchronous,
     'pragma-foreign-keys' => $foreign_keys,
+    'dnssec'              => $dnssec
   }
 
   file { "${::powerdns::config::config_path}/pdns.d/gsqlite3.conf":


### PR DESCRIPTION
See:
- https://doc.powerdns.com/md/authoritative/backend-generic-mysql/#gmysql-dnssec
- https://doc.powerdns.com/md/authoritative/backend-generic-postgresql/#gpgsql-dnssec
- https://doc.powerdns.com/md/authoritative/backend-generic-sqlite/#configuration-parameters
