### PR TITLE
update module dependency version on module puppetlabs/concat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,4 +7,4 @@ fixtures:
       tag:  '4.6.0'
     concat:
       repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
-      tag:  '1.2.2'
+      tag:  '2.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ group :rake, :test do
   gem 'rspec-core',             :require => false
   gem 'rspec-puppet',           :require => false
   gem 'puppetlabs_spec_helper', :require => false
+  #downgrading json gems to build against ruby 1.9.3
+  gem 'json_pure', '<2.0.2'
+  gem 'json', '<2.0.0'
 end
 
 group :rake, :development do

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.2 < 2.0.0"
+      "version_requirement": ">= 1.2.2 <= 2.2.0"
     }
   ]
 }


### PR DESCRIPTION
following PR does:
- update version of module puppetlabs/concat at module dependencies
- update version of module puppetlabs/concat at fixtures for testing

why?
- i wasn't able to use (install) this module along other modules which uses newer (actual) puppetlabs/concat module
