### PR TITLE
Remove '$ensure' parameter from all Concat::Fragment resources.

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -20,7 +20,6 @@ define powerdns::setting (
   $value  = undef,
 ) {
   concat::fragment { $name:
-    ensure  => $ensure,
     target  => "${::powerdns::config::config_path}/pdns.conf",
     content => "${name}=${value}\n",
   }

--- a/spec/defines/setting_spec.rb
+++ b/spec/defines/setting_spec.rb
@@ -23,7 +23,6 @@ describe 'powerdns::setting' do
         should contain_concat__fragment('cache-ttl')
           .with({
             :content => "#{title}=20\n",
-            :ensure  => 'present',
             :target  => config,
           })
       end


### PR DESCRIPTION
This PR removes the `ensure` parameter from all `Concat::Fragment` resources.

The `ensure` parameter is deprecated and has no effect.

Fixes issue #5.