### PR TITLE
Allow multiple settings with the same parameter

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -17,10 +17,12 @@
 
 define powerdns::setting (
   $ensure = 'present',
+  $parameter = $name,
   $value  = undef,
 ) {
   concat::fragment { $name:
     target  => "${::powerdns::config::config_path}/pdns.conf",
-    content => "${name}=${value}\n",
+    content => "${parameter}=${value}\n",
+    order   => $parameter,
   }
 }


### PR DESCRIPTION
This is useful for specifying multiple "append" parameters (+=), for example "allow-axfr-ips+". This way, all the slave nodes can export a `@@powerdns::setting { parameter => "allow-axfr-ips+", value => $::ipaddress_eth0 }`, and the puppet master simply collects the settings.


Since the new `$parameter` parameter defaults to `$name`, this change is backwards-compatible.